### PR TITLE
feat: one click status bar toggle

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,10 @@
         "title": "Translate Selected Text"
       },
       {
+        "command": "interline-translate.toggleTranslatingDocuments",
+        "title": "Toggle translating documents"
+      },
+      {
         "command": "interline-translate.startTranslatingDocuments",
         "title": "Start translating documents"
       },

--- a/src/controller/immersive.ts
+++ b/src/controller/immersive.ts
@@ -131,6 +131,7 @@ export function RegisterTranslator(ctx: Context) {
 
     if (displayOriginalText.value || (!enableContinuousTranslation.value && !enableContinuousTranslationOnce.value))
       return
+
     enableContinuousTranslationOnce.value = false
 
     callingTranslateService.value = true
@@ -208,6 +209,10 @@ export function RegisterTranslator(ctx: Context) {
   extCtx.subscriptions.push(commands.registerCommand('interline-translate.stopTranslatingDocuments', () => {
     enableContinuousTranslation.value = false
     displayOriginalText.value = true
+  }))
+  extCtx.subscriptions.push(commands.registerCommand('interline-translate.toggleTranslatingDocuments', () => {
+    enableContinuousTranslation.value = !enableContinuousTranslation.value
+    displayOriginalText.value = !enableContinuousTranslation.value
   }))
   extCtx.subscriptions.push(commands.registerCommand('interline-translate.translateTheDocumentOnce', () => {
     displayOriginalText.value = false

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -17,10 +17,10 @@ export async function activate(extCtx: vscode.ExtensionContext) {
   console.log('Congratulations, your extension "interline-translate" is now active!')
 
   const ctx = createContext()
+  useExtensionContext.provide(ctx, extCtx)
 
   registerStore(ctx)
 
-  useExtensionContext.provide(ctx, extCtx)
   registerConfig(ctx)
   await RegisterGrammar(ctx)
   RegisterControllers(ctx)

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,16 +1,26 @@
-import { reactive } from '@vue/reactivity'
+import { effect, reactive } from '@vue/reactivity'
 import type { Context } from '~/context'
 import { defineDependency } from '~/context'
+import { useExtensionContext } from '~/dependence'
 
-function initState() {
-  return reactive({
+function initState(ctx: Context) {
+  const ext = useExtensionContext(ctx)
+
+  const enableContinuousTranslation = ext.globalState.get<boolean>('enableContinuousTranslation') ?? false
+  const store = reactive({
     /** Translation is running */
     translating: false,
-    enableContinuousTranslation: false,
+    enableContinuousTranslation,
     enableContinuousTranslationOnce: false,
-    displayOriginalText: true,
+    displayOriginalText: !enableContinuousTranslation,
     callingTranslateService: false,
   })
+
+  effect(() => {
+    ext.globalState.update('enableContinuousTranslation', store.enableContinuousTranslation)
+  })
+
+  return store
 }
 
 type StoreState = ReturnType<typeof initState>
@@ -18,6 +28,6 @@ type StoreState = ReturnType<typeof initState>
 export const useStore = defineDependency<StoreState>('Store')
 
 export function registerStore(ctx: Context) {
-  const state = initState()
+  const state = initState(ctx)
   useStore.provide(ctx, state)
 }

--- a/src/view/statusBar.ts
+++ b/src/view/statusBar.ts
@@ -1,22 +1,26 @@
 import { effect } from '@vue/reactivity'
-import type { StatusBarItem } from 'vscode'
 import { StatusBarAlignment, window } from 'vscode'
 import type { Context } from '~/context'
 import { useStore } from '~/store'
 
-let entryButton: StatusBarItem
-
 export function registerEntryButton(ctx: Context) {
-  entryButton = window.createStatusBarItem(StatusBarAlignment.Right, 0)
+  const entryButton = window.createStatusBarItem(StatusBarAlignment.Right, 757)
+  const settingButton = window.createStatusBarItem(StatusBarAlignment.Right, 756)
   // TODO: need product icons
   const store = useStore(ctx)
+
   effect(() => {
+    settingButton.tooltip = 'Interline Translate Settings'
+    settingButton.text = '$(settings-gear)'
+    settingButton.command = 'interline-translate.showTranslatePopmenu'
+    settingButton.show()
+    entryButton.tooltip = 'Toggle Interline Translate'
     entryButton.text = store.enableContinuousTranslation
       ? store.callingTranslateService
         ? '$(sync~spin) Translating'
-        : '$(pass) translated'
-      : '$(run-all) Translate'
-    entryButton.command = 'interline-translate.showTranslatePopmenu'
+        : '$(pass) Translated'
+      : '$(globe) Translate'
+    entryButton.command = 'interline-translate.toggleTranslatingDocuments'
     entryButton.show()
   })
 }


### PR DESCRIPTION
Make the status bar button a toggle, and move the pop mean as a secondary button:

<img width="232" alt="Screenshot 2024-07-09 at 22 10 34" src="https://github.com/LittleSound/interline-translate/assets/11247099/0d297f2c-34be-458f-b12f-3058e3717911">

Allows users to toggle the feature more easily with one click.

Also persists the enable state in global storage.