### PR TITLE
feat: custom translations

### DIFF
--- a/package.json
+++ b/package.json
@@ -122,6 +122,13 @@
             "type": "string"
           },
           "default": []
+        },
+        "interline-translate.customTranslations": {
+          "type": "object",
+          "items": {
+            "type": "string"
+          },
+          "default": {}
         }
       }
     }

--- a/src/config.ts
+++ b/src/config.ts
@@ -70,6 +70,8 @@ export const config = reactive({
   minWordLength: createConfigRef(`${EXT_NAMESPACE}.minWordLength`, 4),
 
   knownWords: createConfigRef<string[]>(`${EXT_NAMESPACE}.knownWords`, [], undefined, v => v.map(w => w.toLowerCase())),
+
+  customTranslations: createConfigRef<{ [key: string]: string }>(`${EXT_NAMESPACE}.customTranslations`, {}),
 })
 
 export function isKnownWords(word: string) {

--- a/src/controller/immersive.ts
+++ b/src/controller/immersive.ts
@@ -55,8 +55,10 @@ export function RegisterTranslator(ctx: Context) {
 
     const tokens = await parseDocumentToTokens({ textDocument: editor.document })
 
-    for (const { phrase, match } of extractPhrases(text)) {
-      const translatedText = translationCache.get(phrase)
+    for (const { phrase, match, translated } of extractPhrases(text)) {
+      const translatedText = translated
+        ? phrase
+        : translationCache.get(phrase)
       if (!translatedText)
         continue
 

--- a/src/model/extract.ts
+++ b/src/model/extract.ts
@@ -37,6 +37,7 @@ export function *extractPhrases(text: string) {
     nameParts = nameParts.map(part => config.customTranslations[part.toLowerCase()] || part)
 
     // Join the parts back as a sentence
+    // TODO distinguish whether the language uses spaces to separate words.
     phrase = nameParts.join(translated ? '' : ' ')
 
     yield {

--- a/src/model/translator.ts
+++ b/src/model/translator.ts
@@ -39,7 +39,9 @@ export async function translateDocument(ctx: Context, options: TranslateDocument
   const commentsFromDoc: string[] = []
   const stringsFromDoc: string[] = []
 
-  for (const { match, phrase, regex } of extractPhrases(fullText)) {
+  for (const { match, phrase, regex, translated } of extractPhrases(fullText)) {
+    if (translated)
+      continue
     if (translationCache.has(phrase))
       continue
 


### PR DESCRIPTION
fix #2

Before:

<img width="251" alt="Screenshot 2024-07-09 at 23 12 24" src="https://github.com/LittleSound/interline-translate/assets/11247099/88750e4b-aafc-4f5b-9bf9-564742a496cc">

After:

<img width="494" alt="Screenshot 2024-07-09 at 23 15 06" src="https://github.com/LittleSound/interline-translate/assets/11247099/f8b06b02-c19e-4645-8f3e-2d0967b9f83b">

It also supports translation terms by parts separated by `varname`
