### PR TITLE
feat: do not display hint with untranslated content

### DIFF
--- a/src/controller/immersive.ts
+++ b/src/controller/immersive.ts
@@ -63,6 +63,13 @@ export function RegisterTranslator(ctx: Context) {
       if (!translatedText)
         continue
 
+      // Skip if the translated text is the same as input
+      if (
+        translatedText.toLowerCase() === phrase.toLowerCase()
+        || translatedText.toLowerCase() === match[0].toLowerCase()
+      )
+        continue
+
       const startPos = editor.document.positionAt(match.index)
       const endPos = editor.document.positionAt(match.index + phrase.length)
       const range = new Range(startPos, endPos)


### PR DESCRIPTION
Words like `HTML` stays the same after translating, we better not disable hint for them